### PR TITLE
Dockerfile updated to work with local repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,12 @@ ENV GREN_VERSION 0.17.0
 RUN apk add --update git && \
     rm -rf /tmp/* /var/cache/apk/* && \
     npm install github-release-notes@$GREN_VERSION -g
+    
+ENV SRC_PATH /usr/local/src/myapp
+RUN mkdir -p $SRC_PATH
+
+VOLUME [ "$SRC_PATH" ]
+WORKDIR $SRC_PATH
+
+CMD ["--help"]
 ENTRYPOINT ["gren"]

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 # Dockerized github-release-notes
 
+
 Release from the comfort of docker using github-release-notes.
 
 ## Usage
 
 ```console
 export GREN_GITHUB_TOKEN=<your github token>
-docker run --rm -e GREN_GITHUB_TOKEN seriousben/dockerized-github-release-notes <glen command and options>
+docker run --rm -e GREN_GITHUB_TOKEN playground7/glen <glen command and options>
 
 # Release
-docker run --rm -e GREN_GITHUB_TOKEN seriousben/dockerized-github-release-notes release
+docker run --rm -e GREN_GITHUB_TOKEN playground7/glen release
 
 # Changelog
-docker run --rm -e GREN_GITHUB_TOKEN seriousben/dockerized-github-release-notes changelog
+docker run --rm -e GREN_GITHUB_TOKEN playground7/glen changelog
 
 # Changelog and release
-docker run --rm -e GREN_GITHUB_TOKEN seriousben/dockerized-github-release-notes changelog --generate
+docker run --rm -e GREN_GITHUB_TOKEN playground7/glen changelog --generate
 ```
 
 ## Documentation
@@ -27,7 +28,7 @@ All documentation available in https://github.com/github-tools/github-release-no
 ```make
 .PHONY: release
 release:
-	docker run --rm -e GREN_GITHUB_TOKEN seriousben/dockerized-github-release-notes changelog --generate
+	docker run --rm -e GREN_GITHUB_TOKEN playground7/glen changelog --generate
 ```
 
 ## release.sh script
@@ -35,5 +36,5 @@ release:
 ```make
 #!/bin/bash
 set -e
-docker run --rm -e GREN_GITHUB_TOKEN seriousben/dockerized-github-release-notes changelog --generate
+docker run --rm -e GREN_GITHUB_TOKEN playground7/glen changelog --generate
 ```

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ Release from the comfort of docker using github-release-notes.
 
 ```console
 export GREN_GITHUB_TOKEN=<your github token>
-docker run --rm -e GREN_GITHUB_TOKEN playground7/glen <glen command and options>
+docker run --rm -e GREN_GITHUB_TOKEN -v `pwd`:/usr/local/src/myapp playground7/glen <glen command and options>
 
 # Release
-docker run --rm -e GREN_GITHUB_TOKEN playground7/glen release
+docker run --rm -e GREN_GITHUB_TOKEN -v `pwd`:/usr/local/src/myapp playground7/glen release
 
 # Changelog
-docker run --rm -e GREN_GITHUB_TOKEN playground7/glen changelog
+docker run --rm -e GREN_GITHUB_TOKEN -v `pwd`:/usr/local/src/myapp playground7/glen changelog
 
 # Changelog and release
-docker run --rm -e GREN_GITHUB_TOKEN playground7/glen changelog --generate
+docker run --rm -e GREN_GITHUB_TOKEN -v `pwd`:/usr/local/src/myapp playground7/glen changelog --generate
 ```
 
 ## Documentation
@@ -28,7 +28,7 @@ All documentation available in https://github.com/github-tools/github-release-no
 ```make
 .PHONY: release
 release:
-	docker run --rm -e GREN_GITHUB_TOKEN playground7/glen changelog --generate
+	docker run --rm -e GREN_GITHUB_TOKEN -v `pwd`:/usr/local/src/myapp playground7/glen changelog --generate
 ```
 
 ## release.sh script
@@ -36,5 +36,5 @@ release:
 ```make
 #!/bin/bash
 set -e
-docker run --rm -e GREN_GITHUB_TOKEN playground7/glen changelog --generate
+docker run --rm -e GREN_GITHUB_TOKEN -v `pwd`:/usr/local/src/myapp playground7/glen changelog --generate
 ```


### PR DESCRIPTION
Please fix this so that its possible to run from the local git repository.

```
export GREN_GITHUB_TOKEN=<TOKEN>
docker run -it --rm -e GREN_GITHUB_TOKEN  -v $(pwd):/usr/local/src/myapp dockerhub/grenimage changelog  --override
```
Thanks